### PR TITLE
Update pwm1 file every second while fan is running

### DIFF
--- a/src/ats.c
+++ b/src/ats.c
@@ -466,7 +466,12 @@ static int loop_c( lua_State *L ){
 																												thermal_[ 1 ],
 																												pwm );
 			/* Sleeping with Fan ON until next cycle */
-			sleep( Rtimer[ temp ] );
+			// sleep( Rtimer[ temp ] );
+            for (int i = 0; i< Rtimer[ temp ]; i++)
+            {
+                setPwm(instant_ratio);
+                sleep(1);
+            }
 
 			/* Stop Fan */
 			setPwm( 0 );


### PR DESCRIPTION
Changes
*update pwm1 file every 1 second while fan is running

Other
Running on kernel 5.3, the pwm1 file is reset to 0 every 1-5 seconds (i could not figure out by which service), so to keep the fan running, this may help.
I will continue to look for the process modifying the pwm1 file (other than ats).
