### PR TITLE
Add more fan controller paths

### DIFF
--- a/etc/ats.conf
+++ b/etc/ats.conf
@@ -68,7 +68,9 @@ SYSTEM = {
 	PWM_CTL		= {
 			"/sys/class/hwmon/hwmon0/pwm1",
 			"/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1",
-			"/sys/devices/platform/pwm-fan/hwmon/hwmon1/pwm1"
+			"/sys/devices/platform/pwm-fan/hwmon/hwmon1/pwm1",
+			"/sys/devices/platform/pwm-fan/hwmon/hwmon2/pwm1",
+			"/sys/devices/platform/pwm-fan/hwmon/hwmon3/pwm1"
 	},
 
 	--- Temperature Control Constants


### PR DESCRIPTION
Paths under /sys/devices/platform/pwm-fan/hwmon/hwmon* that aren't specified in the configuration are sometimes being used and therefore renders the ATS configuration inadequate. Perhaps there is a more elegant way of wildcarding these paths i.e. `/sys/devices/platform/pwm-fan/hwmon/hwmon*/pwm1`, making it fully dynamic instead.