### PR TITLE
fix: Do not briefly spin up when setting 0 PWM

### DIFF
--- a/src/ats.c
+++ b/src/ats.c
@@ -390,7 +390,7 @@ static void getThermal(){
 **/ 
 static void setPwm( unsigned char  value ){
 	FILE * pwm1 = NULL;
-	if( ! pwm ){
+	if( ! pwm && value != 0){
 		/* When stopped, it needs more power to start...give him 0.2 seconds to rotate poles a bit, so that would be better for aplying bigger push,
 		 * In This Way, initial peak current needed to start fan is lower..
 		 */


### PR DESCRIPTION
Hello, first, let me express my thanks for this project, it made my setup of RockPro64 as a home NAS quite smooth. 

The only problem was that I probably hit issue #28. Looks like whenever ATS wakes up and checks the temperature and derives the correct PWM for the temperature, makes sense. But I think there's a small bug that even if PWM == 0, it runs the procedure to spin up the fan only to set PWM == 0 once it's spinned up. The correct thing to do is probably skip the first branch and directly set PWM if equal to 0 (no fan warm-up necessary in this case).

I've tested this change quite thoughtfully on my machine and from my PoV, it works good. Let me know if I should do any changes to the PR.